### PR TITLE
Fix invoker null pointer

### DIFF
--- a/PlayableSelector/scripts/game/Modded/PS_M_SCR_AIGroup.c
+++ b/PlayableSelector/scripts/game/Modded/PS_M_SCR_AIGroup.c
@@ -18,8 +18,8 @@ modded class SCR_AIGroup : ChimeraAIGroup
 			m_iNameAuthorID = -1;
 		}
 		
-		if (m_bSetPlayable)
-			Event_OnInit.Insert(MakePlayable);
+		if (m_bSetPlayable && GetGame().InPlayMode())
+			GetOnInit().Insert(MakePlayable);
 		
 		super.EOnInit(owner);
 	}


### PR DESCRIPTION
Currently when you open a world, an error occurs (or can occur?) for every placed AI group. This is fixed by the PR.